### PR TITLE
add Makefile for build automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+all: create_account listen4nodes listener keccak
+
+create_account:
+	g++ create_account.cpp -o create_account -lcrypt
+
+listen4nodes:
+	g++ listen4nodes.cpp -o listen4nodes -lcrypt
+
+listener:
+	g++ listener.cpp -o listener
+
+keccak:
+	gcc keccaklogin.c -o keccaklogin -I./Keccak_Headers -L. -lcrypt -lXKCP
+
+clean:
+	rm create_account listen4nodes listener keccaklogin


### PR DESCRIPTION
I mentioned Makefiles during a recent Teams meeting; This is an example to get the project started.

This project now has four binaries associated with it, which makes compilation and testing more challenging. If you use the `Makefile` it is much easier to compile/re-compile and lowers the bar for others to test/contribute. 

How to use:
1. the `make` command from the same folder as the `Makefile` will trigger "all" and compile all the binaries.
2. `make (target)` such as `make listener` will only compile the single target.
3. `make clean` will delete all existing binaries in preperation for re-building with the `make` command (see 1 and 2 above).

There are many benefits to this approach! Updates to the compilation process only need to be added to the `Makefile` to be available to ALL developers (no need to put into README!). Example: Checkout the "keccak" target in the `Makefile`. I setup the compilation to take advantage of the files in the local folder, so there is no need to copy to system wide folders. Developers are very hesitant to manually copy libraries to system locations to test a project!